### PR TITLE
WIP: Vtcompose debugging

### DIFF
--- a/examples/compose/vtcompose/vtcompose.go
+++ b/examples/compose/vtcompose/vtcompose.go
@@ -67,6 +67,14 @@ var (
 	externalDbData = flag.String("externalDbData", DefaultExternalDbData, externalDbDataUsage)
 )
 
+type vtOptions struct {
+	webPort       int
+	gRpcPort      int
+	mySqlPort     int
+	topologyFlags string
+	cell          string
+}
+
 type keyspaceInfo struct {
 	keyspace        string
 	shards          int
@@ -84,14 +92,6 @@ type externalDbInfo struct {
 	dbUser    string
 	dbPass    string
 	dbCharset string
-}
-
-type vtOptions struct {
-	webPort       int
-	gRpcPort      int
-	mySqlPort     int
-	topologyFlags string
-	cell          string
 }
 
 func newKeyspaceInfo(
@@ -118,6 +118,10 @@ func newKeyspaceInfo(
 	return k
 }
 
+func newExternalDbInfo(dbName, dbHost, dbPort, dbUser, dbPass, dbCharset string) externalDbInfo {
+	return externalDbInfo{dbName: dbName, dbHost: dbHost, dbPort: dbPort, dbUser: dbUser, dbPass: dbPass, dbCharset: dbCharset}
+}
+
 func parseKeyspaceInfo(keyspaceData string) map[string]keyspaceInfo {
 	keyspaceInfoMap := make(map[string]keyspaceInfo)
 
@@ -136,10 +140,6 @@ func parseKeyspaceInfo(keyspaceData string) map[string]keyspaceInfo {
 	}
 
 	return keyspaceInfoMap
-}
-
-func newExternalDbInfo(dbName, dbHost, dbPort, dbUser, dbPass, dbCharset string) externalDbInfo {
-	return externalDbInfo{dbName: dbName, dbHost: dbHost, dbPort: dbPort, dbUser: dbUser, dbPass: dbPass, dbCharset: dbCharset}
 }
 
 func parseExternalDbData(externalDbData string) map[string]externalDbInfo {

--- a/examples/compose/vtcompose/vtcompose.go
+++ b/examples/compose/vtcompose/vtcompose.go
@@ -130,7 +130,6 @@ func parseKeyspaceInfo(keyspaceData string) map[string]keyspaceInfo {
 		shards, _ := strconv.Atoi(tokens[1])
 		replicaTablets, _ := strconv.Atoi(tokens[2])
 		schemaFileNames := strings.Split(tokens[3], ",")
-		print(shards)
 
 		if len(tokens) > 4 {
 			keyspaceInfoMap[tokens[0]] = newKeyspaceInfo(tokens[0], shards, replicaTablets, schemaFileNames, tokens[4])
@@ -327,7 +326,6 @@ func getKeyColumns(sqlFile string) string {
 
 	r, _ := regexp.Compile("[^PRIMARY] (KEY|UNIQUE KEY) .*\\((.*)\\).*")
 	rs := r.FindStringSubmatch(string(sqlFileData))
-	print(rs[2])
 	// replace all ` from column names if exists
 	return strings.ReplaceAll(rs[2], "`", "")
 }
@@ -370,8 +368,8 @@ func addLookupDataToVschema(
 		vSchemaFile = applyJsonInMemoryPatch(vSchemaFile, addToColumnVIndexes(lookupTableOwner, firstColumnName, tableName))
 
 		// Generate Vschema lookup hash types
-		vSchemaFile = applyJsonInMemoryPatch(vSchemaFile,
-			generateVschemaLookupHash(tableName, keyspace, firstColumnName, primaryTableColumns[lookupTableOwner], lookupTableOwner))
+		lookupHash := generateVschemaLookupHash(tableName, keyspace, firstColumnName, primaryTableColumns[lookupTableOwner], lookupTableOwner)
+		vSchemaFile = applyJsonInMemoryPatch(vSchemaFile, lookupHash)
 	}
 
 	return vSchemaFile
@@ -525,9 +523,7 @@ func generateDefaultTablet(tabAlias int, shard, role, keyspace string, dbInfo ex
         interval: 30s
         timeout: 10s
         retries: 15
-`,
-		tabAlias, shard, role, opts.webPort, opts.gRpcPort, keyspace, opts.topologyFlags, opts.cell, externalDb,
-		dbInfo.dbPort, dbInfo.dbHost, dbInfo.dbUser, dbInfo.dbPass, dbInfo.dbCharset)
+`, tabAlias, shard, role, opts.webPort, opts.gRpcPort, keyspace, opts.topologyFlags, opts.cell, externalDb, dbInfo.dbPort, dbInfo.dbHost, dbInfo.dbUser, dbInfo.dbPass, dbInfo.dbCharset)
 }
 
 func generateVtctld(opts vtOptions) string {

--- a/examples/compose/vtcompose/vtcompose_test.go
+++ b/examples/compose/vtcompose/vtcompose_test.go
@@ -17,13 +17,348 @@
 package main
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
-func TestPatchedDockerComposeFileIsValid(t *testing.T) {
-	keyspaceInfoMap := make(map[string]keyspaceInfo)
-	externalDbInfoMap := make(map[string]externalDbInfo)
+var (
+	testVtOpts = vtOptions{
+		webPort:       DefaultWebPort,
+		gRpcPort:      DefaultGrpcPort,
+		mySqlPort:     DefaultMysqlPort,
+		topologyFlags: DefaultTopologyFlags,
+		cell:          DefaultCell,
+	}
+	testComposeFile       = readFile("./docker-compose.base.yml")
+	testKeyspaceInfoMap   = parseKeyspaceInfo(DefaultKeyspaceData)
+	testExternalDbInfoMap = parseExternalDbData(DefaultExternalDbData)
+	referenceFile         string
+)
 
-	baseFile := readFile(*baseDockerComposeFile)
-	patchedFile := applyDockerComposePatches(baseFile, keyspaceInfoMap, externalDbInfoMap)
+func TestGeneratesCorrectFileWithDefaultOpts(t *testing.T) {
+	baseFile := testComposeFile
+	finalFile := applyDockerComposePatches(baseFile, testKeyspaceInfoMap, testExternalDbInfoMap, testVtOpts)
+
+	assert.YAMLEq(t, referenceFile, string(finalFile))
+}
+
+func init() {
+	referenceFile = `
+services:
+  consul1:
+    command: agent -server -bootstrap-expect 3 -ui -disable-host-node-id -client 0.0.0.0
+    hostname: consul1
+    image: consul:latest
+    ports:
+    - 8400:8400
+    - 8500:8500
+    - 8600:8600
+  consul2:
+    command: agent -server -retry-join consul1 -disable-host-node-id
+    depends_on:
+    - consul1
+    expose:
+    - "8400"
+    - "8500"
+    - "8600"
+    hostname: consul2
+    image: consul:latest
+  consul3:
+    command: agent -server -retry-join consul1 -disable-host-node-id
+    depends_on:
+    - consul1
+    expose:
+    - "8400"
+    - "8500"
+    - "8600"
+    hostname: consul3
+    image: consul:latest
+  schemaload_test_keyspace:
+    command:
+    - sh
+    - -c
+    - /script/schemaload.sh
+    depends_on:
+      vttablet101:
+        condition: service_healthy
+      vttablet201:
+        condition: service_healthy
+    environment:
+    - TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500
+      -topo_global_root vitess/global
+    - WEB_PORT=8080
+    - GRPC_PORT=15999
+    - CELL=test
+    - KEYSPACE=test_keyspace
+    - TARGETTAB=test-0000000101
+    - SLEEPTIME=15
+    - VSCHEMA_FILE=test_keyspace_vschema.json
+    - SCHEMA_FILES=test_keyspace_schema_file.sql
+    - POST_LOAD_FILE=
+    - EXTERNAL_DB=0
+    image: vitess/base
+    volumes:
+    - .:/script
+  schemaload_unsharded_keyspace:
+    command:
+    - sh
+    - -c
+    - /script/schemaload.sh
+    depends_on:
+      vttablet301:
+        condition: service_healthy
+    environment:
+    - TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500
+      -topo_global_root vitess/global
+    - WEB_PORT=8080
+    - GRPC_PORT=15999
+    - CELL=test
+    - KEYSPACE=unsharded_keyspace
+    - TARGETTAB=test-0000000301
+    - SLEEPTIME=15
+    - VSCHEMA_FILE=unsharded_keyspace_vschema.json
+    - SCHEMA_FILES=unsharded_keyspace_schema_file.sql
+    - POST_LOAD_FILE=
+    - EXTERNAL_DB=0
+    image: vitess/base
+    volumes:
+    - .:/script
+  vtctld:
+    command:
+    - sh
+    - -c
+    - ' $$VTROOT/bin/vtctld -topo_implementation consul -topo_global_server_address
+      consul1:8500 -topo_global_root vitess/global -cell test -workflow_manager_init
+      -workflow_manager_use_election -service_map ''grpc-vtctl'' -backup_storage_implementation
+      file -file_backup_storage_root $$VTDATAROOT/backups -logtostderr=true -port
+      8080 -grpc_port 15999 -pid_file $$VTDATAROOT/tmp/vtctld.pid '
+    depends_on:
+    - consul1
+    - consul2
+    - consul3
+    image: vitess/base
+    ports:
+    - 15000:8080
+    - "15999"
+    volumes:
+    - .:/script
+  vtgate:
+    command:
+    - sh
+    - -c
+    - '/script/run-forever.sh $$VTROOT/bin/vtgate -topo_implementation consul -topo_global_server_address
+      consul1:8500 -topo_global_root vitess/global -logtostderr=true -port 8080 -grpc_port
+      15999 -mysql_server_port 15306 -mysql_auth_server_impl none -cell test -cells_to_watch
+      test -tablet_types_to_wait MASTER,REPLICA,RDONLY -gateway_implementation discoverygateway
+      -service_map ''grpc-vtgateservice'' -pid_file $$VTDATAROOT/tmp/vtgate.pid -normalize_queries=true '
+    depends_on:
+    - vtctld
+    image: vitess/base
+    ports:
+    - 15099:8080
+    - "15999"
+    - 15306:15306
+    volumes:
+    - .:/script
+  vttablet101:
+    command:
+    - sh
+    - -c
+    - /script/vttablet-up.sh 101
+    depends_on:
+    - vtctld
+    environment:
+    - TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500
+      -topo_global_root vitess/global
+    - WEB_PORT=8080
+    - GRPC_PORT=15999
+    - CELL=test
+    - KEYSPACE=test_keyspace
+    - SHARD=-80
+    - ROLE=master
+    - VTHOST=vttablet101
+    - EXTERNAL_DB=0
+    - DB_PORT=
+    - DB_HOST=
+    - DB_USER=
+    - DB_PASS=
+    - DB_CHARSET=
+    healthcheck:
+      interval: 30s
+      retries: 15
+      test:
+      - CMD-SHELL
+      - curl localhost:8080/debug/health
+      timeout: 10s
+    image: vitess/base
+    ports:
+    - 15101:8080
+    - "15999"
+    - "3306"
+    volumes:
+    - .:/script
+  vttablet102:
+    command:
+    - sh
+    - -c
+    - /script/vttablet-up.sh 102
+    depends_on:
+    - vtctld
+    environment:
+    - TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500
+      -topo_global_root vitess/global
+    - WEB_PORT=8080
+    - GRPC_PORT=15999
+    - CELL=test
+    - KEYSPACE=test_keyspace
+    - SHARD=-80
+    - ROLE=replica
+    - VTHOST=vttablet102
+    - EXTERNAL_DB=0
+    - DB_PORT=
+    - DB_HOST=
+    - DB_USER=
+    - DB_PASS=
+    - DB_CHARSET=
+    healthcheck:
+      interval: 30s
+      retries: 15
+      test:
+      - CMD-SHELL
+      - curl localhost:8080/debug/health
+      timeout: 10s
+    image: vitess/base
+    ports:
+    - 15102:8080
+    - "15999"
+    - "3306"
+    volumes:
+    - .:/script
+  vttablet201:
+    command:
+    - sh
+    - -c
+    - /script/vttablet-up.sh 201
+    depends_on:
+    - vtctld
+    environment:
+    - TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500
+      -topo_global_root vitess/global
+    - WEB_PORT=8080
+    - GRPC_PORT=15999
+    - CELL=test
+    - KEYSPACE=test_keyspace
+    - SHARD=80-
+    - ROLE=master
+    - VTHOST=vttablet201
+    - EXTERNAL_DB=0
+    - DB_PORT=
+    - DB_HOST=
+    - DB_USER=
+    - DB_PASS=
+    - DB_CHARSET=
+    healthcheck:
+      interval: 30s
+      retries: 15
+      test:
+      - CMD-SHELL
+      - curl localhost:8080/debug/health
+      timeout: 10s
+    image: vitess/base
+    ports:
+    - 15201:8080
+    - "15999"
+    - "3306"
+    volumes:
+    - .:/script
+  vttablet202:
+    command:
+    - sh
+    - -c
+    - /script/vttablet-up.sh 202
+    depends_on:
+    - vtctld
+    environment:
+    - TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500
+      -topo_global_root vitess/global
+    - WEB_PORT=8080
+    - GRPC_PORT=15999
+    - CELL=test
+    - KEYSPACE=test_keyspace
+    - SHARD=80-
+    - ROLE=replica
+    - VTHOST=vttablet202
+    - EXTERNAL_DB=0
+    - DB_PORT=
+    - DB_HOST=
+    - DB_USER=
+    - DB_PASS=
+    - DB_CHARSET=
+    healthcheck:
+      interval: 30s
+      retries: 15
+      test:
+      - CMD-SHELL
+      - curl localhost:8080/debug/health
+      timeout: 10s
+    image: vitess/base
+    ports:
+    - 15202:8080
+    - "15999"
+    - "3306"
+    volumes:
+    - .:/script
+  vttablet301:
+    command:
+    - sh
+    - -c
+    - /script/vttablet-up.sh 301
+    depends_on:
+    - vtctld
+    environment:
+    - TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500
+      -topo_global_root vitess/global
+    - WEB_PORT=8080
+    - GRPC_PORT=15999
+    - CELL=test
+    - KEYSPACE=unsharded_keyspace
+    - SHARD=-
+    - ROLE=master
+    - VTHOST=vttablet301
+    - EXTERNAL_DB=0
+    - DB_PORT=
+    - DB_HOST=
+    - DB_USER=
+    - DB_PASS=
+    - DB_CHARSET=
+    healthcheck:
+      interval: 30s
+      retries: 15
+      test:
+      - CMD-SHELL
+      - curl localhost:8080/debug/health
+      timeout: 10s
+    image: vitess/base
+    ports:
+    - 15301:8080
+    - "15999"
+    - "3306"
+    volumes:
+    - .:/script
+  vtwork:
+    command:
+    - sh
+    - -c
+    - '$$VTROOT/bin/vtworker -topo_implementation consul -topo_global_server_address
+      consul1:8500 -topo_global_root vitess/global -cell test -logtostderr=true -service_map
+      ''grpc-vtworker'' -port 8080 -grpc_port 15999 -use_v3_resharding_mode=true -pid_file
+      $$VTDATAROOT/tmp/vtwork.pid '
+    depends_on:
+    - vtctld
+    image: vitess/base
+    ports:
+    - 15100:8080
+    - "15999"
+version: "2.1"
+`
 }

--- a/examples/compose/vtcompose/vtcompose_test.go
+++ b/examples/compose/vtcompose/vtcompose_test.go
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 The Vitess Authors.
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *     http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"testing"
+)
+
+func TestPatchedDockerComposeFileIsValid(t *testing.T) {
+	keyspaceInfoMap := make(map[string]keyspaceInfo)
+	externalDbInfoMap := make(map[string]externalDbInfo)
+
+	baseFile := readFile(*baseDockerComposeFile)
+	patchedFile := applyDockerComposePatches(baseFile, keyspaceInfoMap, externalDbInfoMap)
+}


### PR DESCRIPTION
Preliminary PR before I try to upstream this.

Based off of #2.
---

Summary of changes:
 - Add `-debug` flag so that we can attach a remote debug process to the running containers. This:
   + Exposes port 40000 on the vtgate and 40001 on the vtworker;
   + Uses the `vitess/debug` container instead of `vitess/base`
   + Is based off Aaron's previous work in vitess-docker